### PR TITLE
Fixes #71 - json config parser logs if parameter is missing

### DIFF
--- a/cpswt-core/config/src/main/java/org/cpswt/config/ConfigParser.java
+++ b/cpswt-core/config/src/main/java/org/cpswt/config/ConfigParser.java
@@ -1,6 +1,8 @@
 package org.cpswt.config;
 
 import com.fasterxml.jackson.core.JsonFactory;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonToken;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 import java.io.File;
@@ -11,9 +13,25 @@ import java.io.IOException;
  */
 public class ConfigParser {
 
-    public static <TConfig> TConfig parseConfig(File configFile, final Class<TConfig> clazz) throws IOException {
+    public static <TConfig extends FederateConfig> TConfig parseFederateConfig(File configFile, final Class<TConfig> clazz) throws IOException {
 
-        ObjectMapper mapper = new ObjectMapper(new JsonFactory());
+        JsonFactory jsonFactory = new JsonFactory();
+        ObjectMapper mapper = new ObjectMapper(jsonFactory);
+        TConfig configObj = mapper.readValue(configFile, clazz);
+
+        // "save" which fields were set from the config file
+        JsonParser jsonParser = jsonFactory.createParser(configFile);
+        while(jsonParser.nextToken() != JsonToken.END_OBJECT) {
+            String fieldName = jsonParser.getCurrentName();
+            configObj.fieldsSet.add(fieldName);
+        }
+
+        return configObj;
+    }
+
+    public static <TConfig> TConfig parseConfig(File configFile, final Class<TConfig> clazz) throws IOException {
+        JsonFactory jsonFactory = new JsonFactory();
+        ObjectMapper mapper = new ObjectMapper(jsonFactory);
         TConfig configObj = mapper.readValue(configFile, clazz);
 
         return configObj;

--- a/cpswt-core/config/src/main/java/org/cpswt/config/FederateConfig.java
+++ b/cpswt-core/config/src/main/java/org/cpswt/config/FederateConfig.java
@@ -1,16 +1,20 @@
 package org.cpswt.config;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
-import org.apache.commons.cli.*;
-
-import org.apache.commons.lang3.ClassUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+
+import java.lang.reflect.Field;
+import java.util.HashSet;
+import java.util.Set;
 
 /**
  * Represents the parameter object for a federate.
  */
 public class FederateConfig {
+
+    @JsonIgnore
+    final Set<String> fieldsSet = new HashSet<>();
 
     @JsonIgnore
     static final Logger logger = LogManager.getLogger(FederateConfig.class);
@@ -53,8 +57,10 @@ public class FederateConfig {
 
     /**
      * Optional 'name' parameter that will be acquired as 'id'
+     * Use {@link FederateParameterOptional} to exclude the field from "isSet" check
      */
     @FederateParameter
+    @FederateParameterOptional
     public String name;
 
     /**
@@ -76,5 +82,34 @@ public class FederateConfig {
         this.isLateJoiner = isLateJoiner;
         this.lookAhead = lookAhead;
         this.stepSize = stepSize;
+    }
+
+    @JsonIgnore
+    public static Set<Field> getFederateParameterFields(Class<? extends  FederateConfig> configClass) {
+        Set<Field> fieldSet = new HashSet<>();
+        Field[] fields = configClass.getFields();
+
+        for (Field field : fields) {
+            if (field.getAnnotation(FederateParameter.class) != null) {
+                fieldSet.add(field);
+            }
+        }
+
+        return fieldSet;
+    }
+
+    @JsonIgnore
+    public static Set<Field> getMandatoryFederateParameterFields(Class<? extends  FederateConfig> configClass) {
+        Set<Field> fieldSet = new HashSet<>();
+        Field[] fields = configClass.getFields();
+
+        for (Field field : fields) {
+            if (field.getAnnotation(FederateParameter.class) != null
+                    && field.getAnnotation(FederateParameterOptional.class) == null) {
+                fieldSet.add(field);
+            }
+        }
+
+        return fieldSet;
     }
 }

--- a/cpswt-core/config/src/main/java/org/cpswt/config/FederateParameterOptional.java
+++ b/cpswt-core/config/src/main/java/org/cpswt/config/FederateParameterOptional.java
@@ -1,0 +1,12 @@
+package org.cpswt.config;
+
+import java.lang.annotation.*;
+
+/**
+ * Annotation to indicate an OPTIONAL parameter of a federate config.
+ */
+@Documented
+@Target(ElementType.FIELD)
+@Inherited
+@Retention(RetentionPolicy.RUNTIME)
+public @interface FederateParameterOptional {}


### PR DESCRIPTION
* JSON config parser logs if parameter is missing from JSON config or from command line arguments
* Added `@FederateParameterOptional` to indicate if a parameter is not mandatory