### PR TITLE
Only one federate name can be appended to the "federateSequence" para…

### DIFF
--- a/cpswt-core/base-events/src/main/java/org/cpswt/hla/InteractionRoot_p/C2WInteractionRoot.java
+++ b/cpswt-core/base-events/src/main/java/org/cpswt/hla/InteractionRoot_p/C2WInteractionRoot.java
@@ -35,10 +35,9 @@ import java.util.HashSet;
 import java.util.Set;
 import java.util.List;
 import java.util.ArrayList;
-import java.util.regex.Pattern;
-import java.util.regex.Matcher;
 
 import org.json.JSONArray;
+import org.json.JSONException;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -463,16 +462,32 @@ public class C2WInteractionRoot extends org.cpswt.hla.InteractionRoot {
     // END PROPERTY MANIPULATION METHODS
     //----------------------------------
 
-    private static Pattern federateSequenceRegex = Pattern.compile(
-      "\\s*\\[(?:\\s*\"(?:[^\"]|(?:\\\\)*\\\")+\",)*\\s*\"(?:[^\"]|(?:\\\\)*\\\")+\"\\s*\\]\\s*"
-    );
-
     private static boolean is_federate_sequence(String federateSequence) {
-        Matcher matcher = federateSequenceRegex.matcher( federateSequence );
-        return matcher.matches();
+
+        JSONArray jsonArray;
+
+        try {
+            jsonArray = new JSONArray( federateSequence );
+        } catch (JSONException jsonException) {
+            return false;
+        }
+
+        int jsonArrayLength = jsonArray.length();
+        for(int ix = 0 ; ix < jsonArrayLength ; ++ix) {
+            if (!(jsonArray.get(ix) instanceof String)) {
+                return false;
+            }
+        }
+        return true;
     }
 
     private static void update_federate_sequence_aux(org.cpswt.hla.InteractionRoot interactionRoot, String federateId) {
+
+        if (org.cpswt.hla.InteractionRoot.get_federate_appended_to_federate_sequence(interactionRoot)) {
+            return;
+        }
+        org.cpswt.hla.InteractionRoot.set_federate_appended_to_federate_sequence(interactionRoot);
+
         String federateSequence = (String)interactionRoot.getParameter("federateSequence");
 
         JSONArray jsonArray = is_federate_sequence( federateSequence ) ?

--- a/cpswt-core/base-events/src/test/java/org/cpswt/hla/MessagingTests.java
+++ b/cpswt-core/base-events/src/test/java/org/cpswt/hla/MessagingTests.java
@@ -484,15 +484,19 @@ public class MessagingTests {
         String string4 = "string4";
         double doubleValue4 = 17.3;
 
+        // AS ONLY ONE FEDERATE NAME CAN BE ADDED TO THE federateSequence OF AN INTERACTION THAT IS DERIVED FROM
+        // "InteractionRoot.C2WInteractionRoot" USING EITHER THE "update_federate_sequence" or "updateFederateSequence"
+        // METHODS, THESE METHODS WILL NOT CHANGE THE "federateSequence" FOR simLogInteraction AFTER THE
+        // CALL TO "update_federate_sequence" ABOVE
         simLogInteraction.updateFederateSequence(string4);
         simLogInteraction.set_Time(doubleValue4);
 
         federateSequenceList = simLogInteraction.getFederateSequenceList();
         Assert.assertEquals(string3, federateSequenceList.get(0));
-        Assert.assertEquals(string4, federateSequenceList.get(federateSequenceList.size() - 1));
+        Assert.assertEquals(string3, federateSequenceList.get(federateSequenceList.size() - 1));
         Assert.assertEquals(doubleValue4, simLogInteraction.getParameter("Time"));
 
-        Assert.assertEquals(string4, simLogInteraction.getSourceFederateId());
+        Assert.assertEquals(string3, simLogInteraction.getSourceFederateId());
         Assert.assertEquals(string3, simLogInteraction.getOriginFederateId());
         Assert.assertEquals(doubleValue4, simLogInteraction.get_Time(), 0.01);
     }
@@ -532,6 +536,59 @@ public class MessagingTests {
         Assert.assertTrue( federateObject.isInstanceHlaClassDerivedFromHlaClass("ObjectRoot"));
         Assert.assertTrue( federateObject.isInstanceHlaClassDerivedFromHlaClass("ObjectRoot.FederateObject"));
         Assert.assertTrue( federateObject.isInstanceOfHlaClass("ObjectRoot.FederateObject"));
+    }
+
+    @Test
+    public void federateSequenceTest() {
+
+        // CHECK federateSequence THAT STARTS OUT EMPTY
+        InteractionRoot interactionRoot1 = new InteractionRoot("InteractionRoot.C2WInteractionRoot.SimLog");
+
+        String federateName1 = "federateName1";
+
+        // ADD federateName1 TO federateSequence
+        C2WInteractionRoot.update_federate_sequence(interactionRoot1, federateName1);
+
+        // MAKE SURE IT'S THERE
+        List<String> federateSequenceList1 = C2WInteractionRoot.get_federate_sequence_list(interactionRoot1);
+
+        Assert.assertEquals(1, federateSequenceList1.size());
+        Assert.assertEquals(federateName1, federateSequenceList1.get(0));
+
+        // ADD IT AGAIN
+        C2WInteractionRoot.update_federate_sequence(interactionRoot1, federateName1);
+
+        // MAKE SURE federateSequence IS UNCHANGED
+        List<String> federateSequenceList2 = C2WInteractionRoot.get_federate_sequence_list(interactionRoot1);
+
+        Assert.assertEquals(1, federateSequenceList2.size());
+        Assert.assertEquals(federateName1, federateSequenceList2.get(0));
+
+
+        // CHECK federateSequence THAT STARTS OUT NON-EMPTY
+        InteractionRoot interactionRoot2 = new InteractionRoot("InteractionRoot.C2WInteractionRoot.SimLog");
+
+        List<String> federateNameList = new ArrayList<>(Arrays.asList("federateName2", "federateName3"));
+
+        JSONArray jsonArray = new JSONArray(federateNameList);
+        interactionRoot2.setParameter("federateSequence", jsonArray.toString());
+
+        // ADD federateName1 TO federateSequence
+        C2WInteractionRoot.update_federate_sequence(interactionRoot2, federateName1);
+
+        // MAKE SURE IT'S THERE
+        List<String> federateSequenceList3 = C2WInteractionRoot.get_federate_sequence_list(interactionRoot2);
+        federateNameList.add(federateName1);
+
+        Assert.assertEquals(federateNameList, federateSequenceList3);
+
+        // ADD IT AGAIN
+        C2WInteractionRoot.update_federate_sequence(interactionRoot2, federateName1);
+
+        // MAKE SURE federateSequence IS UNCHANGED
+        List<String> federateSequenceList4 = C2WInteractionRoot.get_federate_sequence_list(interactionRoot2);
+
+        Assert.assertEquals(federateNameList, federateSequenceList3);
     }
 
     @Test

--- a/cpswt-core/root/src/main/java/org/cpswt/hla/InteractionRoot.java
+++ b/cpswt-core/root/src/main/java/org/cpswt/hla/InteractionRoot.java
@@ -227,6 +227,17 @@ public class InteractionRoot implements InteractionRootInterface {
         _instanceHlaClassName = instanceHlaClassName;
     }
 
+    // FOR INTERACTIONS DERIVED FROM InteractionRoot.C2WInteractionRoot
+    protected boolean federateAppendedToFederateSequence = false;
+
+    protected static void set_federate_appended_to_federate_sequence(InteractionRoot interactionRoot) {
+        interactionRoot.federateAppendedToFederateSequence = true;
+    }
+
+    protected static boolean get_federate_appended_to_federate_sequence(InteractionRoot interactionRoot) {
+        return interactionRoot.federateAppendedToFederateSequence;
+    }
+
     public static String get_simple_class_name(String hlaClassName) {
         if (hlaClassName == null) {
             return null;


### PR DESCRIPTION
…meter of an interaction derived from "InteractionRoot.C2WInteractionRoot" -- attempts to add more federate name fail silently.